### PR TITLE
fix error with p90 array

### DIFF
--- a/SpinCore_pp/ppg/echo.py
+++ b/SpinCore_pp/ppg/echo.py
@@ -112,10 +112,10 @@ def run_spin_echo(
             [
                 ("phase_reset", 1),
                 ("delay_TTL", deblank_us),
-                ("pulse_TTL", prog_p90_us.item(), "ph1", ph1_cyc),
+                ("pulse_TTL", prog_p90_us, "ph1", ph1_cyc),
                 ("delay", tau_us),
                 ("delay_TTL", deblank_us),
-                ("pulse_TTL", prog_p180_us.item(), "ph2", ph2_cyc),
+                ("pulse_TTL", prog_p180_us, "ph2", ph2_cyc),
                 ("delay", deadtime_us),
                 ("acquire", acq_time_ms),
                 ("delay", repetition_us),

--- a/SpinCore_pp/ppg/echo.py
+++ b/SpinCore_pp/ppg/echo.py
@@ -112,10 +112,10 @@ def run_spin_echo(
             [
                 ("phase_reset", 1),
                 ("delay_TTL", deblank_us),
-                ("pulse_TTL", prog_p90_us, "ph1", ph1_cyc),
+                ("pulse_TTL", prog_p90_us.item(), "ph1", ph1_cyc),
                 ("delay", tau_us),
                 ("delay_TTL", deblank_us),
-                ("pulse_TTL", prog_p180_us, "ph2", ph2_cyc),
+                ("pulse_TTL", prog_p180_us.item(), "ph2", ph2_cyc),
                 ("delay", deadtime_us),
                 ("acquire", acq_time_ms),
                 ("delay", repetition_us),

--- a/SpinCore_pp/pulse_length_conv.py
+++ b/SpinCore_pp/pulse_length_conv.py
@@ -72,5 +72,8 @@ def prog_plen(desired_actual):
         else:
             c = calibration_data.polyfit("plen", order=1)
         return np.polyval(c[::-1], desired_actual)
-
-    return np.vectorize(zonefit)(desired_actual)
+    ret_val = np.vectorize(zonefit)(desired_actual)
+    if ret_val.size > 1:
+        return ret_val
+    else:
+        return ret_val.item()


### PR DESCRIPTION
not sure what heppened but when I run FLInst NMRsignal on master I get this error ```
Traceback (most recent call last):
  File "C:\ProgramData\Anaconda3\scripts\FLInst-script.py", line 11, in <module>
    load_entry_point('francklab-instruments', 'console_scripts', 'FLInst')()
  File "c:\apps-su\flinst\Instruments\cmd.py", line 27, in cmd
    cmds[sys.argv[1]]()
  File "c:\apps-su\flinst\Instruments\nmr_signal_gui.py", line 442, in main
    tunwin = NMRWindow(x, myconfig)
  File "c:\apps-su\flinst\Instruments\nmr_signal_gui.py", line 43, in __init__
    self.acq_NMR()
  File "c:\apps-su\flinst\Instruments\nmr_signal_gui.py", line 187, in acq_NMR
    self.generate_data()
  File "c:\apps-su\flinst\Instruments\nmr_signal_gui.py", line 149, in generate_data
    ret_data=None,
  File "c:\apps-su\flinst\SpinCore_pp\ppg\echo.py", line 123, in run_spin_echo
    ("delay", repetition_us),
  File "c:\apps-su\flinst\SpinCore_pp\SpinCore_pp.py", line 208, in load
    ppg_element(*a_tuple)
TypeError: in method 'ppg_element', argument 2 of type 'double'
```
After investigation I find that the p90 and p180 we feed to the SpinCore.load is an array and not a float